### PR TITLE
Readme cleanup; fix link; nix Board Mngr Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ http://move38.com
 This core requires at least Arduino IDE v1.6.2, where v1.6.5+ is recommended. <br/>
 * [Programmers](#programmers)
 * **[How to install](#how-to-install)**
-	- [Boards Manager Installation](#boards-manager-installation)
-	- [Manual Installation](#manual-installation)
 * **[Getting started](#getting-started)**
 
 * **[Digging deeper](#digging-deeper)**
@@ -24,32 +22,14 @@ Just connect your programmer and select it in the "Programmers" menu, and connec
 You can then use the "Sketch-Upload to Programmer" menu choice or just press the Play button to compile your code and program it into the connected tile. (Both the menu option and the button do the same thing with a tile.)
 
 ## How to install
-#### Boards Manager Installation
-This installation method requires Arduino IDE version 1.6.4 or greater.
-* Open the Arduino IDE.
-* Open the **File > Preferences** menu item.
-* Enter the following URL in **Additional Boards Manager URLs**:
 
-    ```
-    https://bigjosh.github.io//package_index.json
-    ``` 
-
-* Open the **Tools > Board > Boards Manager...** menu item.
-* Wait for the platform indexes to finish downloading.
-* Scroll down until you see the **Move38** entry and click on it.
-  * **Note**: If you are using Arduino IDE 1.6.6 then you may need to close **Boards Manager** and then reopen it before the **Move38** entry will appear.
-* Click **Install**.
-* After installation is complete close the **Boards Manager** window.
-
-
-#### Manual Installation
-You should probably only  do manual install if you plan on hacking the blinks API and contributing changes back up to the master repo on Github. 
-
-Click on the "Download ZIP" button in the upper right corner. Extract the ZIP file, and move the extracted files to the location "**~/Documents/Arduino/hardware/Move38-manual/avr**". Create the folder if it doesn't exist. This readme file should be located at "**~/Documents/Arduino/hardware/Move38-manual/avr/README.md**" when you are done.
+Click on the "Download ZIP" button in the upper right corner of this repo. Extract the ZIP file, and move the extracted files to the location "**~/Documents/Arduino/hardware/Move38-manual/avr**". Create the folder if it doesn't exist. This readme file should be located at "**~/Documents/Arduino/hardware/Move38-manual/avr/README.md**" when you are done.
 
 Open Arduino IDE, and a new category in the boards menu called "Move38-manual" will show up.
 
-##### Notes 
+In the future, we'll offer a simplified Arduino Boards Manager install path.
+
+### Notes 
 
 * We called the "vendor/maintainer" folder `Move38-manual` so that you can also use the boards manager and you will be able to tell the two apart in the boards menu.
 
@@ -70,4 +50,4 @@ The IDE should compile the code and program the Blinks tile... and you should se
 
 #### Hardware Abstraction Layer
 
-Most programmers will want to use the high level `blinks` API, but if you want to get closer to the hardware you can directly call into the `HAL` (Hardware Abstraction Layer) that the `blinks` API is built on top of. Documentation for this layer is in the [README.md](cores/blinks/README.md) in the `cores/blinks` folder.
+Most programmers will want to use the high level `blinks` API, but if you want to get closer to the hardware you can directly call into the `HAL` (Hardware Abstraction Layer) that the `blinks` API is built on top of. Documentation for this layer is in the [README.md](cores/blinkcore/README.md) in the `cores/blinkscore` folder.


### PR DESCRIPTION
We can restore the Board Manager install instructions once that install path is ready to go.