### PR TITLE
Freeze time

### DIFF
--- a/AS7/blink/Sketches/Blink/main.cpp
+++ b/AS7/blink/Sketches/Blink/main.cpp
@@ -40,7 +40,7 @@ static int sourceFace=NO_FACE; // The face we got the spark from.
 static int targetFace=NO_FACE; // The face we are sending the spark to.
                                // Only matters in BURN state. NO_FACE if we are not spreading
 
-static uint32_t nextStateTime;        // Time we switch to next state. Valid in EXPLODING, COOLDOWN, and INFECT.
+Timer nextState;			   // Time we switch to next state. Valid in EXPLODING, COOLDOWN, and INFECT.
 
 // How long between when we first get a spark and start sending a new spark
 static const uint16_t igniteDurration_ms = 200;
@@ -147,10 +147,10 @@ void loop() {
   
     if (detonateFlag) {
         state=IGNITE;
-        nextStateTime=millis()+igniteDurration_ms;
+        nextState.setMSFromNow( igniteDurration_ms );
     }      
       
-    if ( nextStateTime < millis() ) {        // Time for next timed state transition?
+    if ( nextState.isExpired() ) {        // Time for next timed state transition?
         
         // These are the only states that can timeout
         
@@ -163,12 +163,12 @@ void loop() {
             targetFace = pickSparkTarget( sourceFace );
             
             state=BURN;
-            nextStateTime=millis()+burnDuration_ms;
+            nextState.setMSFromNow( burnDuration_ms );
             
         } else if (state==BURN) {              // Technically don't need this `if` since this is the only possible case, but here for clarity.             
             
             state=READY;
-            nextStateTime=NEVER;                 
+            nextState.setNever();                 
             
         }                
                 

--- a/AS7/blink/Sketches/Blink/main.cpp
+++ b/AS7/blink/Sketches/Blink/main.cpp
@@ -99,8 +99,9 @@ static byte pickSparkTarget( byte exclude ) {
 
 void loop() {
         
+         
     // put your main code here, to run repeatedly:
-    uint32_t now = millis();
+
   
     bool detonateFlag = false;        // Set this flag to true to cause detonation
                                       // since the ignition can come from either button or spark
@@ -146,10 +147,10 @@ void loop() {
   
     if (detonateFlag) {
         state=IGNITE;
-        nextStateTime=now+igniteDurration_ms;
+        nextStateTime=millis()+igniteDurration_ms;
     }      
       
-    if ( nextStateTime < now ) {        // Time for next timed state transition?
+    if ( nextStateTime < millis() ) {        // Time for next timed state transition?
         
         // These are the only states that can timeout
         
@@ -162,7 +163,7 @@ void loop() {
             targetFace = pickSparkTarget( sourceFace );
             
             state=BURN;
-            nextStateTime=now+burnDuration_ms;
+            nextStateTime=millis()+burnDuration_ms;
             
         } else if (state==BURN) {              // Technically don't need this `if` since this is the only possible case, but here for clarity.             
             

--- a/libraries/blinklib/src/blinklib.cpp
+++ b/libraries/blinklib/src/blinklib.cpp
@@ -521,6 +521,23 @@ unsigned long millis(void) {
     return( tempMillis );
 }
 
+// Note we directlyt access millis() here, which is really bad style.
+// The timer should capture millis() in a closure, but no good way to 
+// do that in C++ that is not verbose and inefficient, so here we are. 
+
+bool Timer::isExpired() {
+	return millis() >= expireTime; 
+}
+	
+void Timer::setMsFromNow( uint32_t ms ) {
+	expireTime= millis()+ms;	
+}
+	
+void Timer::setSecondsFromNow( uint16_t s ) {
+	setMsFromNow(s*MILLIS_PER_SECOND);
+}
+
+
 /*
 
 // Delay for `ms` milliseconds

--- a/libraries/blinklib/src/blinklib.cpp
+++ b/libraries/blinklib/src/blinklib.cpp
@@ -526,15 +526,20 @@ unsigned long millis(void) {
 // do that in C++ that is not verbose and inefficient, so here we are. 
 
 bool Timer::isExpired() {
-	return millis() >= expireTime; 
+	return millis() >= m_expireTime; 
 }
 	
-void Timer::setMsFromNow( uint32_t ms ) {
-	expireTime= millis()+ms;	
+void Timer::setMSFromNow( uint32_t ms ) {
+	m_expireTime= millis()+ms;	
 }
 	
 void Timer::setSecondsFromNow( uint16_t s ) {
-	setMsFromNow(s*MILLIS_PER_SECOND);
+	setMSFromNow(s*MILLIS_PER_SECOND);
+}
+
+
+void Timer::setNever() {
+	m_expireTime=NEVER;
 }
 
 

--- a/libraries/blinklib/src/blinklib.h
+++ b/libraries/blinklib/src/blinklib.h
@@ -212,13 +212,15 @@ void setFaceColor(  byte face, Color newColor );
 
 */
 
-// Number of milliseconds since we started (since last time setup called).
-// Note that this can increase by more than 1 between calls, so always use greater than
-// and less than rather than equals for comparisons
-
-// Overflows after about 50 days
-
-// Note that our clock is only accurate to about +/-10%
+// Number of running milliseconds since power up.
+//
+// Important notes:
+// 1) does not increment while sleeping
+// 2) is only updated between loop() interations
+// 3) is not monotonic, so always use greater than
+//    and less than rather than equals for comparisons
+// 4) overflows after about 50 days
+// 5) is only accurate to about +/-10%
 
 unsigned long millis(void);
 

--- a/libraries/blinklib/src/blinklib.h
+++ b/libraries/blinklib/src/blinklib.h
@@ -230,18 +230,21 @@ unsigned long millis(void);
 
 class Timer {
 	
-	uint32_t expireTime;		// When this timer will expire
+	private: 
+		
+		uint32_t m_expireTime;		// When this timer will expire
 	
 	public:
 	
-		Timer() : expireTime(0) {};		// Timers come into this world pre-expired. 
+		Timer() : m_expireTime(0) {};		// Timers come into this world pre-expired. 
 			
 		bool isExpired();
 				
-		void setMsFromNow( uint32_t ms );
+		void setMSFromNow( uint32_t ms );
 		
 		void setSecondsFromNow( uint16_t s );
-					
+		
+		void setNever();					
 };
 
 

--- a/libraries/blinklib/src/blinklib.h
+++ b/libraries/blinklib/src/blinklib.h
@@ -226,6 +226,25 @@ unsigned long millis(void);
 
 #define NEVER ( (uint32_t)-1 )          // UINT32_MAX would be correct here, but generates a Symbol Not Found. 
 
+
+
+class Timer {
+	
+	uint32_t expireTime;		// When this timer will expire
+	
+	public:
+	
+		Timer() : expireTime(0) {};		// Timers come into this world pre-expired. 
+			
+		bool isExpired();
+				
+		void setMsFromNow( uint32_t ms );
+		
+		void setSecondsFromNow( uint16_t s );
+					
+};
+
+
 /*
 
     Utility functions


### PR DESCRIPTION
The change is subtle, but abstracts away millis() so people don't even know what type it is.

Also automatically gets rid of some race conditions and boundary problems people are likely to have writing this stuff over and over again on their own.

Finally, opens opportunities for optimization by, say, internally processing ticks rather than milliseconds, in which case we only have to do the conversion a single time when the timer is set- and even then that can happen at compile time for constant values.